### PR TITLE
Ensure @user value is populated in template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,8 @@
 # == Class: activemq::config
 class activemq::config {
 
+  $user = $::activemq::user
+
   file {'/etc/default/activemq':
     ensure  => present,
     owner   => 'root',


### PR DESCRIPTION
Resolves  https://github.com/jbussdieker/puppet-activemq/issues/3

This ensures that the user variable is taken from the class and not another source
